### PR TITLE
Add test coverage for backtester and ingesters modules

### DIFF
--- a/tests/test_backtester_chunks.py
+++ b/tests/test_backtester_chunks.py
@@ -1,0 +1,250 @@
+import unittest
+import sys
+import os
+import asyncio
+from datetime import date
+from unittest import mock
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pandas as pd
+import numpy as np
+
+from data_manager.data_reader import DataReader
+from strategies.momentum import Signal
+from backtester import BackTester, Trade
+
+
+class TestBacktesterChunks(unittest.TestCase):
+    """Test cases for chunk processing in the BackTester class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.data_reader = mock.MagicMock(spec=DataReader)
+
+        # Create sample data for testing
+        dates = pd.date_range(start='2023-01-01', end='2023-01-31', freq='D')
+        self.sample_data = pd.DataFrame({
+            'open': np.linspace(100, 120, len(dates)),
+            'high': np.linspace(105, 125, len(dates)),
+            'low': np.linspace(95, 115, len(dates)),
+            'close': np.linspace(102, 122, len(dates)),
+            'adjusted_close': np.linspace(102, 122, len(dates)),
+            'volume': np.random.randint(1000, 10000, len(dates))
+        }, index=dates.date)
+
+        # Initialize the backtester
+        self.backtester = BackTester(
+            data_reader=self.data_reader,
+            initial_capital=10000,
+            transaction_cost_pct=0.1
+        )
+
+    async def test_backtest_sequential_with_chunks(self):
+        """Test backtesting with data chunks."""
+        # Create chunks of data
+        chunk_size = 10
+        chunks = []
+        for i in range(0, len(self.sample_data), chunk_size):
+            chunks.append(self.sample_data.iloc[i:i+chunk_size].copy())
+
+        # Configure the mock data_reader to return chunks
+        self.data_reader.get_data = mock.AsyncMock(return_value=chunks)
+
+        # Create signals with a buy at the beginning and sell at the end
+        signals_chunks = []
+        for i, chunk in enumerate(chunks):
+            if i == 0:  # First chunk has a buy signal
+                signals = pd.DataFrame({
+                    'signal': [Signal.BUY.value] + [Signal.HOLD.value] * (len(chunk) - 1)
+                }, index=chunk.index)
+            elif i == len(chunks) - 1:  # Last chunk has a sell signal
+                signals = pd.DataFrame({
+                    'signal': [Signal.HOLD.value] * (len(chunk) - 1) + [Signal.SELL.value]
+                }, index=chunk.index)
+            else:  # Middle chunks have hold signals
+                signals = pd.DataFrame({
+                    'signal': [Signal.HOLD.value] * len(chunk)
+                }, index=chunk.index)
+            signals_chunks.append(signals)
+
+        # Create a mock strategy that returns our signal chunks
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=signals_chunks)
+
+        # Run the backtest with chunks
+        report = await self.backtester._backtest_sequential(
+            strategy=mock_strategy,
+            symbol='AAPL',
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 31),
+            chunk_size=chunk_size
+        )
+
+        # Verify the results
+        self.assertEqual(report.symbol, 'AAPL')
+        self.assertEqual(len(report.trades), 1)  # One complete trade
+        
+        # Check the trade details
+        trade = report.trades[0]
+        self.assertEqual(trade.symbol, 'AAPL')
+        self.assertEqual(trade.entry_date, date(2023, 1, 1))  # Buy signal in first chunk
+        self.assertEqual(trade.exit_date, date(2023, 1, 31))  # Sell signal in last chunk
+
+        # Verify that profit was made (since prices are increasing)
+        self.assertGreater(trade.exit_price, trade.entry_price)
+        self.assertGreater(trade.profit_pct, 0)
+
+        # Verify that final capital is greater than initial (profitable trade)
+        self.assertGreater(report.final_capital, report.initial_capital)
+
+    async def test_process_data_chunk(self):
+        """Test the _process_data_chunk method directly."""
+        # Create a small chunk of data
+        dates = pd.date_range(start='2023-01-01', end='2023-01-05', freq='D')
+        data_chunk = pd.DataFrame({
+            'open': [100, 102, 104, 106, 108],
+            'high': [105, 107, 109, 111, 113],
+            'low': [95, 97, 99, 101, 103],
+            'close': [102, 104, 106, 108, 110],
+            'signal': [Signal.BUY.value, Signal.HOLD.value, Signal.HOLD.value, Signal.HOLD.value, Signal.SELL.value]
+        }, index=dates.date)
+
+        # Initial state
+        capital = 10000
+        position = 0
+        trades = []
+        current_trade = None
+        symbol = 'AAPL'
+
+        # Process the chunk
+        capital, position, trades, current_trade, equity_curve = self.backtester._process_data_chunk(
+            data=data_chunk,
+            capital=capital,
+            position=position,
+            trades=trades,
+            current_trade=current_trade,
+            symbol=symbol
+        )
+
+        # Verify the results
+        self.assertEqual(len(trades), 1)  # One complete trade
+        self.assertEqual(position, 0)  # No position at the end
+        self.assertIsNone(current_trade)  # No open trade at the end
+        
+        # Check the trade details
+        trade = trades[0]
+        self.assertEqual(trade.symbol, 'AAPL')
+        self.assertEqual(trade.entry_date, date(2023, 1, 1))  # Buy signal on first day
+        self.assertEqual(trade.exit_date, date(2023, 1, 5))  # Sell signal on last day
+        self.assertEqual(trade.entry_price, 102)
+        self.assertEqual(trade.exit_price, 110)
+
+        # Verify that profit was made
+        self.assertGreater(trade.profit_pct, 0)
+        self.assertGreater(capital, 10000)  # Capital increased
+
+        # Verify equity curve
+        self.assertEqual(len(equity_curve), 5)  # One point for each day
+        self.assertTrue(all(not pd.isna(value) for value in equity_curve))
+
+    async def test_error_handling_missing_data(self):
+        """Test error handling when data is missing."""
+        # Configure the mock data_reader to return empty data
+        self.data_reader.get_data = mock.AsyncMock(return_value=pd.DataFrame())
+
+        # Create a mock strategy that returns empty signals
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=pd.DataFrame())
+
+        # Run the backtest
+        report = await self.backtester.backtest(
+            strategy=mock_strategy,
+            symbol='AAPL',
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 31)
+        )
+
+        # Verify the results
+        self.assertEqual(report.symbol, 'AAPL')
+        self.assertEqual(len(report.trades), 0)  # No trades
+        self.assertEqual(report.final_capital, 10000)  # Capital unchanged
+        self.assertTrue(report.equity_curve.empty)  # Empty equity curve
+
+    async def test_short_backtest(self):
+        """Test a very short backtest (1-2 days)."""
+        # Create a small dataset
+        dates = pd.date_range(start='2023-01-01', end='2023-01-02', freq='D')
+        short_data = pd.DataFrame({
+            'open': [100, 102],
+            'high': [105, 107],
+            'low': [95, 97],
+            'close': [102, 104],
+            'adjusted_close': [102, 104],
+            'volume': [5000, 6000]
+        }, index=dates.date)
+
+        # Configure the mock data_reader to return the short data
+        self.data_reader.get_data = mock.AsyncMock(return_value=short_data)
+
+        # Create signals with a buy on day 1 and sell on day 2
+        signals = pd.DataFrame({
+            'signal': [Signal.BUY.value, Signal.SELL.value]
+        }, index=dates.date)
+
+        # Create a mock strategy that returns our signals
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=signals)
+
+        # Run the backtest
+        report = await self.backtester.backtest(
+            strategy=mock_strategy,
+            symbol='AAPL',
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 2)
+        )
+
+        # Verify the results
+        self.assertEqual(report.symbol, 'AAPL')
+        self.assertEqual(len(report.trades), 1)  # One complete trade
+        
+        # Check the trade details
+        trade = report.trades[0]
+        self.assertEqual(trade.symbol, 'AAPL')
+        self.assertEqual(trade.entry_date, date(2023, 1, 1))
+        self.assertEqual(trade.exit_date, date(2023, 1, 2))
+        self.assertEqual(trade.entry_price, 102)
+        self.assertEqual(trade.exit_price, 104)
+
+        # Verify that profit was made
+        self.assertGreater(trade.profit_pct, 0)
+        self.assertGreater(report.final_capital, 10000)
+
+
+# Create an AsyncioTestCase class to handle async tests
+class AsyncioTestCase(unittest.TestCase):
+    """Base class for asyncio test cases."""
+
+    def run_async(self, coro):
+        """Run a coroutine in the event loop."""
+        return asyncio.run(coro)
+
+
+# Modify the TestBacktesterChunks class to use AsyncioTestCase
+TestBacktesterChunks.__bases__ = (AsyncioTestCase,)
+
+
+# Wrap async test methods to run them with run_async
+for name in dir(TestBacktesterChunks):
+    if name.startswith('test_') and asyncio.iscoroutinefunction(getattr(TestBacktesterChunks, name)):
+        method = getattr(TestBacktesterChunks, name)
+
+        def wrapper(self, method=method):
+            return self.run_async(method(self))
+
+        setattr(TestBacktesterChunks, name, wrapper)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_backtester_edge_cases.py
+++ b/tests/test_backtester_edge_cases.py
@@ -1,0 +1,233 @@
+import unittest
+import sys
+import os
+import asyncio
+from datetime import date
+from unittest import mock
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pandas as pd
+import numpy as np
+
+from data_manager.data_reader import DataReader
+from strategies.momentum import Signal
+from backtester import BackTester, Trade
+
+
+class TestBacktesterEdgeCases(unittest.TestCase):
+    """Test cases for edge cases in the BackTester class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.data_reader = mock.MagicMock(spec=DataReader)
+
+        # Create sample data for testing
+        dates = pd.date_range(start='2023-01-01', end='2023-01-31', freq='D')
+        self.sample_data = pd.DataFrame({
+            'open': np.linspace(100, 120, len(dates)),
+            'high': np.linspace(105, 125, len(dates)),
+            'low': np.linspace(95, 115, len(dates)),
+            'close': np.linspace(102, 122, len(dates)),
+            'adjusted_close': np.linspace(102, 122, len(dates)),
+            'volume': np.random.randint(1000, 10000, len(dates))
+        }, index=dates.date)
+
+    async def test_invalid_signals(self):
+        """Test backtesting with invalid signals."""
+        # Configure the mock data_reader to return the sample data
+        self.data_reader.get_data = mock.AsyncMock(return_value=self.sample_data.copy())
+
+        # Create signals with invalid values
+        dates = pd.date_range(start='2023-01-01', end='2023-01-31', freq='D')
+        signals = pd.DataFrame({
+            'signal': [Signal.BUY.value] + ['INVALID'] * 5 + [Signal.SELL.value] + [Signal.HOLD.value] * 24
+        }, index=dates.date)
+
+        # Create a mock strategy that returns our signals
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=signals)
+
+        # Create a backtester
+        backtester = BackTester(
+            data_reader=self.data_reader,
+            initial_capital=10000,
+            transaction_cost_pct=0.1
+        )
+
+        # Run the backtest
+        report = await backtester.backtest(
+            strategy=mock_strategy,
+            symbol='AAPL',
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 31)
+        )
+
+        # Verify the results - invalid signals should be ignored
+        self.assertEqual(report.symbol, 'AAPL')
+        self.assertEqual(len(report.trades), 1)  # One complete trade
+        
+        # Check the trade details
+        trade = report.trades[0]
+        self.assertEqual(trade.symbol, 'AAPL')
+        self.assertEqual(trade.entry_date, date(2023, 1, 1))  # Buy signal on first day
+        self.assertEqual(trade.exit_date, date(2023, 1, 7))  # Sell signal on day 7
+
+    async def test_different_transaction_costs(self):
+        """Test backtesting with different transaction costs."""
+        # Configure the mock data_reader to return the sample data
+        self.data_reader.get_data = mock.AsyncMock(return_value=self.sample_data.copy())
+
+        # Create signals with one buy and one sell
+        dates = pd.date_range(start='2023-01-01', end='2023-01-31', freq='D')
+        signals = pd.DataFrame({
+            'signal': [Signal.BUY.value] + [Signal.HOLD.value] * 29 + [Signal.SELL.value]
+        }, index=dates.date)
+
+        # Create a mock strategy that returns our signals
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=signals)
+
+        # Test with different transaction costs
+        transaction_costs = [0.0, 0.1, 0.5, 1.0, 2.0]
+        final_capitals = []
+
+        for cost in transaction_costs:
+            # Create a backtester with this transaction cost
+            backtester = BackTester(
+                data_reader=self.data_reader,
+                initial_capital=10000,
+                transaction_cost_pct=cost
+            )
+
+            # Run the backtest
+            report = await backtester.backtest(
+                strategy=mock_strategy,
+                symbol='AAPL',
+                start_date=date(2023, 1, 1),
+                end_date=date(2023, 1, 31)
+            )
+
+            # Store the final capital
+            final_capitals.append(report.final_capital)
+
+        # Verify that higher transaction costs result in lower final capital
+        for i in range(1, len(transaction_costs)):
+            self.assertLess(final_capitals[i], final_capitals[i-1])
+
+    async def test_multiple_consecutive_signals(self):
+        """Test backtesting with multiple consecutive buy/sell signals."""
+        # Configure the mock data_reader to return the sample data
+        self.data_reader.get_data = mock.AsyncMock(return_value=self.sample_data.copy())
+
+        # Create signals with multiple consecutive buys and sells
+        dates = pd.date_range(start='2023-01-01', end='2023-01-31', freq='D')
+        signals = pd.DataFrame({
+            'signal': [Signal.BUY.value, Signal.BUY.value, Signal.HOLD.value, Signal.HOLD.value, Signal.SELL.value, 
+                      Signal.SELL.value, Signal.HOLD.value, Signal.BUY.value, Signal.HOLD.value, Signal.SELL.value] + 
+                      [Signal.HOLD.value] * 21
+        }, index=dates.date)
+
+        # Create a mock strategy that returns our signals
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=signals)
+
+        # Create a backtester
+        backtester = BackTester(
+            data_reader=self.data_reader,
+            initial_capital=10000,
+            transaction_cost_pct=0.1
+        )
+
+        # Run the backtest
+        report = await backtester.backtest(
+            strategy=mock_strategy,
+            symbol='AAPL',
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 31)
+        )
+
+        # Verify the results - only the first buy and first sell after that should be processed
+        self.assertEqual(report.symbol, 'AAPL')
+        self.assertEqual(len(report.trades), 2)  # Two complete trades
+        
+        # Check the first trade
+        trade1 = report.trades[0]
+        self.assertEqual(trade1.symbol, 'AAPL')
+        self.assertEqual(trade1.entry_date, date(2023, 1, 1))  # First buy signal
+        self.assertEqual(trade1.exit_date, date(2023, 1, 5))  # First sell signal after buy
+        
+        # Check the second trade
+        trade2 = report.trades[1]
+        self.assertEqual(trade2.symbol, 'AAPL')
+        self.assertEqual(trade2.entry_date, date(2023, 1, 8))  # Second buy signal
+        self.assertEqual(trade2.exit_date, date(2023, 1, 10))  # Second sell signal
+
+    async def test_no_sell_signal(self):
+        """Test backtesting with a buy signal but no sell signal."""
+        # Configure the mock data_reader to return the sample data
+        self.data_reader.get_data = mock.AsyncMock(return_value=self.sample_data.copy())
+
+        # Create signals with only a buy signal
+        dates = pd.date_range(start='2023-01-01', end='2023-01-31', freq='D')
+        signals = pd.DataFrame({
+            'signal': [Signal.BUY.value] + [Signal.HOLD.value] * 30
+        }, index=dates.date)
+
+        # Create a mock strategy that returns our signals
+        mock_strategy = mock.MagicMock()
+        mock_strategy.generate_signals = mock.AsyncMock(return_value=signals)
+
+        # Create a backtester
+        backtester = BackTester(
+            data_reader=self.data_reader,
+            initial_capital=10000,
+            transaction_cost_pct=0.1
+        )
+
+        # Run the backtest
+        report = await backtester.backtest(
+            strategy=mock_strategy,
+            symbol='AAPL',
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 1, 31)
+        )
+
+        # Verify the results - position should be closed at the end of the backtest
+        self.assertEqual(report.symbol, 'AAPL')
+        self.assertEqual(len(report.trades), 1)  # One trade
+        
+        # Check the trade details
+        trade = report.trades[0]
+        self.assertEqual(trade.symbol, 'AAPL')
+        self.assertEqual(trade.entry_date, date(2023, 1, 1))  # Buy signal on first day
+        self.assertEqual(trade.exit_date, date(2023, 1, 31))  # Exit at the end of the backtest
+
+
+# Create an AsyncioTestCase class to handle async tests
+class AsyncioTestCase(unittest.TestCase):
+    """Base class for asyncio test cases."""
+
+    def run_async(self, coro):
+        """Run a coroutine in the event loop."""
+        return asyncio.run(coro)
+
+
+# Modify the TestBacktesterEdgeCases class to use AsyncioTestCase
+TestBacktesterEdgeCases.__bases__ = (AsyncioTestCase,)
+
+
+# Wrap async test methods to run them with run_async
+for name in dir(TestBacktesterEdgeCases):
+    if name.startswith('test_') and asyncio.iscoroutinefunction(getattr(TestBacktesterEdgeCases, name)):
+        method = getattr(TestBacktesterEdgeCases, name)
+
+        def wrapper(self, method=method):
+            return self.run_async(method(self))
+
+        setattr(TestBacktesterEdgeCases, name, wrapper)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_daily_data_ingester.py
+++ b/tests/test_daily_data_ingester.py
@@ -1,0 +1,233 @@
+import unittest
+import sys
+import os
+import json
+import asyncio
+import pandas as pd
+from unittest import mock
+from pathlib import Path
+from io import StringIO
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import aiohttp
+from ingesters.DailyDataIngester import process_symbol, main
+from data_manager.alpha_vantage import AsyncAlphaVantageDownloader
+from data_manager.symbol_manager import SymbolManager
+from config import config
+
+
+class TestDailyDataIngester(unittest.TestCase):
+    """Test cases for the DailyDataIngester module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a mock session
+        self.mock_session = mock.MagicMock(spec=aiohttp.ClientSession)
+
+        # Create the downloader with the mock session
+        self.downloader = AsyncAlphaVantageDownloader(session=self.mock_session, verify_ssl=False)
+
+        # Sample data for testing
+        self.sample_time_series_data = {
+            "Meta Data": {
+                "1. Information": "Daily Time Series with Adjusted close and volume",
+                "2. Symbol": "AAPL",
+                "3. Last Refreshed": "2023-01-31",
+                "4. Output Size": "Full size",
+                "5. Time Zone": "US/Eastern"
+            },
+            "Time Series (Daily)": {
+                "2023-01-31": {
+                    "1. open": "142.7000",
+                    "2. high": "144.3400",
+                    "3. low": "142.2800",
+                    "4. close": "144.2900",
+                    "5. adjusted close": "144.2900",
+                    "6. volume": "86903491",
+                    "7. dividend amount": "0.0000",
+                    "8. split coefficient": "1.0000"
+                },
+                "2023-01-30": {
+                    "1. open": "143.1600",
+                    "2. high": "143.3100",
+                    "3. low": "142.0000",
+                    "4. close": "143.0000",
+                    "5. adjusted close": "143.0000",
+                    "6. volume": "64015367",
+                    "7. dividend amount": "0.0000",
+                    "8. split coefficient": "1.0000"
+                }
+            }
+        }
+
+        # Create a temporary directory for test files
+        self.temp_dir = mock.MagicMock()
+        self.temp_dir.name = "/tmp/test_daily_data"
+        
+        # Mock config paths
+        self.original_data_json_location = config.DATA_JSON_LOCATION
+        self.original_data_pickle_location = config.DATA_PICKLE_LOCATION
+        config.DATA_JSON_LOCATION = os.path.join(self.temp_dir.name, "json")
+        config.DATA_PICKLE_LOCATION = os.path.join(self.temp_dir.name, "pickle")
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        # Restore original config paths
+        config.DATA_JSON_LOCATION = self.original_data_json_location
+        config.DATA_PICKLE_LOCATION = self.original_data_pickle_location
+
+    @mock.patch('os.makedirs')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('pandas.DataFrame.from_dict')
+    @mock.patch('pandas.DataFrame.to_pickle')
+    async def test_process_symbol_success(self, mock_to_pickle, mock_from_dict, mock_open, mock_makedirs):
+        """Test successful processing of a symbol."""
+        # Mock the DataFrame creation
+        mock_df = mock.MagicMock()
+        mock_from_dict.return_value = mock_df
+
+        # Create a mock downloader that returns our sample data
+        mock_downloader = mock.MagicMock()
+        mock_downloader.download = mock.AsyncMock(return_value=self.sample_time_series_data)
+
+        # Create a mock semaphore
+        mock_sem = mock.MagicMock()
+        mock_sem.__aenter__ = mock.AsyncMock(return_value=None)
+        mock_sem.__aexit__ = mock.AsyncMock(return_value=None)
+
+        # Create a list to track not found symbols
+        not_found = []
+
+        # Call the process_symbol function
+        await process_symbol("AAPL", mock_downloader, not_found, mock_sem)
+
+        # Verify that the downloader was called with the correct symbol
+        mock_downloader.download.assert_called_once_with("AAPL")
+
+        # Verify that the JSON file was opened and written
+        mock_open.assert_called_with(os.path.join(config.DATA_JSON_LOCATION, "AAPL.json"), "w")
+        mock_open().write.assert_called_once()
+
+        # Verify that the DataFrame was created and saved as pickle
+        mock_from_dict.assert_called_once_with(self.sample_time_series_data["Time Series (Daily)"], orient="index")
+        mock_to_pickle.assert_called_once_with(os.path.join(config.DATA_PICKLE_LOCATION, "AAPL.pkl.gz"), compression="gzip")
+
+        # Verify that the symbol was not added to the not_found list
+        self.assertEqual(not_found, [])
+
+    @mock.patch('os.makedirs')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    async def test_process_symbol_no_time_series(self, mock_open, mock_makedirs):
+        """Test processing a symbol with no time series data."""
+        # Create sample data with no time series
+        data_no_time_series = {
+            "Meta Data": {
+                "1. Information": "Daily Time Series with Adjusted close and volume",
+                "2. Symbol": "INVALID",
+                "3. Last Refreshed": "2023-01-31",
+                "4. Output Size": "Full size",
+                "5. Time Zone": "US/Eastern"
+            }
+        }
+
+        # Create a mock downloader that returns data with no time series
+        mock_downloader = mock.MagicMock()
+        mock_downloader.download = mock.AsyncMock(return_value=data_no_time_series)
+
+        # Create a mock semaphore
+        mock_sem = mock.MagicMock()
+        mock_sem.__aenter__ = mock.AsyncMock(return_value=None)
+        mock_sem.__aexit__ = mock.AsyncMock(return_value=None)
+
+        # Create a list to track not found symbols
+        not_found = []
+
+        # Call the process_symbol function
+        await process_symbol("INVALID", mock_downloader, not_found, mock_sem)
+
+        # Verify that the downloader was called with the correct symbol
+        mock_downloader.download.assert_called_once_with("INVALID")
+
+        # Verify that the JSON file was opened and written
+        mock_open.assert_called_with(os.path.join(config.DATA_JSON_LOCATION, "INVALID.json"), "w")
+        mock_open().write.assert_called_once()
+
+        # Verify that the symbol was added to the not_found list
+        self.assertEqual(not_found, ["INVALID"])
+
+    @mock.patch('os.makedirs')
+    @mock.patch('os.path.exists')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('asyncio.gather')
+    @mock.patch('ingesters.DailyDataIngester.process_symbol')
+    @mock.patch('data_manager.symbol_manager.SymbolManager')
+    async def test_main_function(self, mock_symbol_manager_class, mock_process_symbol, 
+                                mock_gather, mock_open, mock_exists, mock_makedirs):
+        """Test the main function of the DailyDataIngester."""
+        # Mock os.path.exists to return True for missing_symbols.txt
+        mock_exists.return_value = True
+
+        # Mock open to return a file with missing symbols
+        mock_open.return_value.__enter__.return_value.readlines.return_value = ["MISSING1\n", "MISSING2\n"]
+
+        # Mock SymbolManager
+        mock_symbol_manager = mock.MagicMock()
+        mock_symbol_manager.get_symbols_space_separated.return_value = ["AAPL", "MSFT", "GOOG"]
+        mock_symbol_manager.save_symbols_to_file.return_value = "symbols.txt"
+        mock_symbol_manager_class.return_value = mock_symbol_manager
+
+        # Mock process_symbol to track calls
+        mock_process_symbol.return_value = None
+
+        # Mock gather to return None
+        mock_gather.return_value = None
+
+        # Call the main function
+        await main()
+
+        # Verify that directories were created
+        self.assertEqual(mock_makedirs.call_count, 3)  # daily_dir, json_dir, pickle_dir
+
+        # Verify that SymbolManager was initialized and used
+        mock_symbol_manager.load_russell_1000_symbols.assert_called_once()
+        mock_symbol_manager.get_symbols_space_separated.assert_called_once()
+        mock_symbol_manager.save_symbols_to_file.assert_called_once_with("symbols.txt")
+
+        # Verify that process_symbol was called for each symbol
+        # 3 regular symbols + 2 missing symbols = 5 calls
+        self.assertEqual(mock_process_symbol.call_count, 5)
+
+        # Verify that gather was called once
+        mock_gather.assert_called_once()
+
+        # Verify that the missing symbols file was written
+        mock_open.assert_called_with(mock.ANY, "w")
+
+
+class AsyncioTestCase(unittest.TestCase):
+    """Base class for asyncio test cases."""
+
+    def run_async(self, coro):
+        """Run a coroutine in the event loop."""
+        return asyncio.run(coro)
+
+
+# Modify the TestDailyDataIngester class to use AsyncioTestCase
+TestDailyDataIngester.__bases__ = (AsyncioTestCase,)
+
+
+# Wrap async test methods to run them with run_async
+for name in dir(TestDailyDataIngester):
+    if name.startswith('test_') and asyncio.iscoroutinefunction(getattr(TestDailyDataIngester, name)):
+        method = getattr(TestDailyDataIngester, name)
+
+        def wrapper(self, method=method):
+            return self.run_async(method(self))
+
+        setattr(TestDailyDataIngester, name, wrapper)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_intraday_data_ingester.py
+++ b/tests/test_intraday_data_ingester.py
@@ -1,0 +1,318 @@
+import unittest
+import sys
+import os
+import json
+import asyncio
+import pandas as pd
+from unittest import mock
+from pathlib import Path
+from datetime import datetime
+from io import StringIO
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import aiohttp
+from ingesters.IntradayDataIngester import process_symbol, main, generate_month_list
+from data_manager.alpha_vantage import AsyncAlphaVantageDownloader
+from data_manager.symbol_manager import SymbolManager
+from config import config
+
+
+class TestIntradayDataIngester(unittest.TestCase):
+    """Test cases for the IntradayDataIngester module."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a mock session
+        self.mock_session = mock.MagicMock(spec=aiohttp.ClientSession)
+
+        # Create the downloader with the mock session
+        self.downloader = AsyncAlphaVantageDownloader(session=self.mock_session, verify_ssl=False)
+
+        # Sample data for testing
+        self.sample_time_series_data = {
+            "Meta Data": {
+                "1. Information": "Intraday (60min) open, high, low, close prices and volume",
+                "2. Symbol": "AAPL",
+                "3. Last Refreshed": "2023-01-31 16:00:00",
+                "4. Interval": "60min",
+                "5. Output Size": "Full size",
+                "6. Time Zone": "US/Eastern"
+            },
+            "Time Series (60min)": {
+                "2023-01-31 16:00:00": {
+                    "1. open": "142.7000",
+                    "2. high": "144.3400",
+                    "3. low": "142.2800",
+                    "4. close": "144.2900",
+                    "5. volume": "8690349"
+                },
+                "2023-01-31 15:00:00": {
+                    "1. open": "143.1600",
+                    "2. high": "143.3100",
+                    "3. low": "142.0000",
+                    "4. close": "143.0000",
+                    "5. volume": "6401536"
+                }
+            }
+        }
+
+        # Create a temporary directory for test files
+        self.temp_dir = mock.MagicMock()
+        self.temp_dir.name = "/tmp/test_intraday_data"
+        
+        # Mock config paths
+        self.original_data_root_dir = config.DATA_ROOT_DIR
+        config.DATA_ROOT_DIR = self.temp_dir.name
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        # Restore original config paths
+        config.DATA_ROOT_DIR = self.original_data_root_dir
+
+    def test_generate_month_list(self):
+        """Test the generate_month_list function."""
+        # Test with a specific start year and month
+        with mock.patch('ingesters.IntradayDataIngester.datetime') as mock_datetime:
+            # Mock the current date to be 2023-03-15
+            mock_now = mock.MagicMock()
+            mock_now.year = 2023
+            mock_now.month = 3
+            mock_datetime.now.return_value = mock_now
+
+            # Generate months from 2022-06 to 2023-03
+            months = generate_month_list(2022, 6)
+
+            # Expected months in reverse order (most recent first)
+            expected_months = [
+                "2023-03", "2023-02", "2023-01", 
+                "2022-12", "2022-11", "2022-10", "2022-09", "2022-08", "2022-07", "2022-06"
+            ]
+
+            self.assertEqual(months, expected_months)
+
+    def test_generate_month_list_current_year(self):
+        """Test generate_month_list with the current year."""
+        # Get the current year and month
+        current_date = datetime.now()
+        current_year = current_date.year
+        current_month = current_date.month
+
+        # Generate months from the beginning of the current year
+        months = generate_month_list(current_year, 1)
+
+        # Expected months in reverse order (most recent first)
+        expected_months = []
+        for month in range(current_month, 0, -1):
+            expected_months.append(f"{current_year}-{month:02d}")
+
+        self.assertEqual(months, expected_months)
+
+    @mock.patch('os.makedirs')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('pandas.DataFrame.from_dict')
+    @mock.patch('pandas.DataFrame.to_pickle')
+    async def test_process_symbol_success(self, mock_to_pickle, mock_from_dict, mock_open, mock_makedirs):
+        """Test successful processing of a symbol with intraday data."""
+        # Mock the DataFrame creation
+        mock_df = mock.MagicMock()
+        mock_from_dict.return_value = mock_df
+
+        # Create a mock downloader that returns our sample data
+        mock_downloader = mock.MagicMock()
+        mock_downloader.download = mock.AsyncMock(return_value=self.sample_time_series_data)
+
+        # Create a mock semaphore
+        mock_sem = mock.MagicMock()
+        mock_sem.__aenter__ = mock.AsyncMock(return_value=None)
+        mock_sem.__aexit__ = mock.AsyncMock(return_value=None)
+
+        # Create a list to track not found symbols
+        not_found = []
+
+        # Call the process_symbol function
+        await process_symbol("AAPL", mock_downloader, not_found, mock_sem, interval="60min")
+
+        # Verify that the downloader was called with the correct parameters
+        # Note: We expect multiple calls for each month, but in our test we're mocking to return the same data
+        mock_downloader.download.assert_called_with(
+            "AAPL", 
+            function="TIME_SERIES_INTRADAY", 
+            interval="60min",
+            month=mock.ANY,
+            outputsize="full"
+        )
+
+        # Verify that the JSON file was opened and written
+        json_dir = Path(config.DATA_ROOT_DIR) / "intraday" / "json" / "60min"
+        mock_open.assert_called_with(json_dir / "AAPL.json", "w")
+        mock_open().write.assert_called_once()
+
+        # Verify that the DataFrame was created and saved as pickle
+        mock_from_dict.assert_called_once_with(mock.ANY, orient="index")
+        pickle_dir = Path(config.DATA_ROOT_DIR) / "intraday" / "pickle" / "60min"
+        mock_to_pickle.assert_called_once_with(pickle_dir / "AAPL.pkl.gz", compression="gzip")
+
+        # Verify that the symbol was not added to the not_found list
+        self.assertEqual(not_found, [])
+
+    @mock.patch('os.makedirs')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    async def test_process_symbol_no_data(self, mock_open, mock_makedirs):
+        """Test processing a symbol with no intraday data."""
+        # Create a mock downloader that returns empty data
+        mock_downloader = mock.MagicMock()
+        mock_downloader.download = mock.AsyncMock(return_value={})
+
+        # Create a mock semaphore
+        mock_sem = mock.MagicMock()
+        mock_sem.__aenter__ = mock.AsyncMock(return_value=None)
+        mock_sem.__aexit__ = mock.AsyncMock(return_value=None)
+
+        # Create a list to track not found symbols
+        not_found = []
+
+        # Call the process_symbol function
+        await process_symbol("INVALID", mock_downloader, not_found, mock_sem, interval="60min")
+
+        # Verify that the downloader was called
+        mock_downloader.download.assert_called()
+
+        # Verify that the symbol was added to the not_found list
+        self.assertEqual(not_found, ["INVALID"])
+
+    @mock.patch('os.makedirs')
+    @mock.patch('os.path.exists')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('asyncio.gather')
+    @mock.patch('ingesters.IntradayDataIngester.process_symbol')
+    @mock.patch('data_manager.symbol_manager.SymbolManager')
+    async def test_main_function(self, mock_symbol_manager_class, mock_process_symbol, 
+                                mock_gather, mock_open, mock_exists, mock_makedirs):
+        """Test the main function of the IntradayDataIngester."""
+        # Mock os.path.exists to return True for missing_symbols files
+        mock_exists.return_value = True
+
+        # Mock open to return a file with missing symbols
+        mock_file = mock.MagicMock()
+        mock_file.readlines.return_value = ["MISSING1\n", "MISSING2\n"]
+        mock_file.__enter__.return_value = mock_file
+        mock_open.return_value = mock_file
+
+        # Mock SymbolManager
+        mock_symbol_manager = mock.MagicMock()
+        mock_symbol_manager.get_symbols_space_separated.return_value = ["AAPL", "MSFT", "GOOG"]
+        mock_symbol_manager.save_symbols_to_file.return_value = "symbols.txt"
+        mock_symbol_manager_class.return_value = mock_symbol_manager
+
+        # Mock process_symbol to track calls
+        mock_process_symbol.return_value = None
+
+        # Mock gather to return None
+        mock_gather.return_value = None
+
+        # Call the main function
+        await main()
+
+        # Verify that directories were created
+        self.assertTrue(mock_makedirs.called)
+
+        # Verify that SymbolManager was initialized and used
+        mock_symbol_manager.load_russell_1000_symbols.assert_called_once()
+        mock_symbol_manager.get_symbols_space_separated.assert_called_once()
+        mock_symbol_manager.save_symbols_to_file.assert_called_once_with("symbols.txt")
+
+        # Verify that process_symbol was called
+        self.assertTrue(mock_process_symbol.called)
+
+        # Verify that gather was called
+        mock_gather.assert_called()
+
+        # Verify that the missing symbols file was written
+        self.assertTrue(mock_open.called)
+
+    @mock.patch('ingesters.IntradayDataIngester.generate_month_list')
+    @mock.patch('os.makedirs')
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('pandas.DataFrame.from_dict')
+    @mock.patch('pandas.DataFrame.to_pickle')
+    async def test_process_symbol_consecutive_empty_months(self, mock_to_pickle, mock_from_dict, 
+                                                         mock_open, mock_makedirs, mock_generate_month_list):
+        """Test processing a symbol with consecutive empty months."""
+        # Mock generate_month_list to return a fixed list of months
+        mock_generate_month_list.return_value = ["2023-03", "2023-02", "2023-01", "2022-12", "2022-11"]
+
+        # Mock the DataFrame creation
+        mock_df = mock.MagicMock()
+        mock_from_dict.return_value = mock_df
+
+        # Create a mock downloader that returns data for some months and empty for others
+        mock_downloader = mock.MagicMock()
+        
+        # First month has data
+        first_month_data = dict(self.sample_time_series_data)
+        mock_downloader.download.side_effect = [
+            # First month has data
+            first_month_data,
+            # Next 3 months have no data (empty time series)
+            {"Meta Data": first_month_data["Meta Data"]},
+            {"Meta Data": first_month_data["Meta Data"]},
+            {"Meta Data": first_month_data["Meta Data"]},
+            # Last month would have data but shouldn't be called due to max_consecutive_empty
+        ]
+
+        # Create a mock semaphore
+        mock_sem = mock.MagicMock()
+        mock_sem.__aenter__ = mock.AsyncMock(return_value=None)
+        mock_sem.__aexit__ = mock.AsyncMock(return_value=None)
+
+        # Create a list to track not found symbols
+        not_found = []
+
+        # Call the process_symbol function
+        await process_symbol("AAPL", mock_downloader, not_found, mock_sem, interval="60min")
+
+        # Verify that the downloader was called only 4 times (not 5)
+        # First call + 3 consecutive empty months = 4 calls
+        self.assertEqual(mock_downloader.download.call_count, 4)
+
+        # Verify that the JSON file was opened and written
+        json_dir = Path(config.DATA_ROOT_DIR) / "intraday" / "json" / "60min"
+        mock_open.assert_called_with(json_dir / "AAPL.json", "w")
+        mock_open().write.assert_called_once()
+
+        # Verify that the DataFrame was created and saved as pickle
+        mock_from_dict.assert_called_once_with(mock.ANY, orient="index")
+        pickle_dir = Path(config.DATA_ROOT_DIR) / "intraday" / "pickle" / "60min"
+        mock_to_pickle.assert_called_once_with(pickle_dir / "AAPL.pkl.gz", compression="gzip")
+
+        # Verify that the symbol was not added to the not_found list
+        self.assertEqual(not_found, [])
+
+
+class AsyncioTestCase(unittest.TestCase):
+    """Base class for asyncio test cases."""
+
+    def run_async(self, coro):
+        """Run a coroutine in the event loop."""
+        return asyncio.run(coro)
+
+
+# Modify the TestIntradayDataIngester class to use AsyncioTestCase
+TestIntradayDataIngester.__bases__ = (AsyncioTestCase,)
+
+
+# Wrap async test methods to run them with run_async
+for name in dir(TestIntradayDataIngester):
+    if name.startswith('test_') and asyncio.iscoroutinefunction(getattr(TestIntradayDataIngester, name)):
+        method = getattr(TestIntradayDataIngester, name)
+
+        def wrapper(self, method=method):
+            return self.run_async(method(self))
+
+        setattr(TestIntradayDataIngester, name, wrapper)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit adds comprehensive test coverage for the previously untested or inadequately tested modules:

## Backtester Module
- Created test_backtester_chunks.py with tests for:
  * chunk processing in the _backtest_sequential method
  * _process_data_chunk method
  * error handling when data is missing
  * very short backtests (1-2 days)

- Created test_backtester_edge_cases.py with tests for:
  * invalid signals
  * different transaction costs
  * multiple consecutive buy/sell signals
  * scenarios with no sell signal

## Ingesters Module
- Created test_daily_data_ingester.py with tests for:
  * process_symbol function
  * main function
  * error handling for missing time series data

- Created test_intraday_data_ingester.py with tests for:
  * generate_month_list function
  * process_symbol function
  * main function
  * handling of consecutive empty months
  * error handling for missing data